### PR TITLE
[Fix] 매일 분석 업데이트 시 기존 row 변경

### DIFF
--- a/src/main/java/com/factseekerbackend/domain/politician/entity/PoliticianTrustScore.java
+++ b/src/main/java/com/factseekerbackend/domain/politician/entity/PoliticianTrustScore.java
@@ -157,4 +157,13 @@ public class PoliticianTrustScore {
     public boolean canRetry() {
         return this.retryCount < 3;
     }
+
+    public void setAnalysisDate(LocalDate analysisDate) {
+        this.analysisDate = analysisDate;
+    }
+
+    public void setAnalysisPeriod(String analysisPeriod) {
+        this.analysisPeriod = analysisPeriod;
+    }
+    
 }

--- a/src/main/java/com/factseekerbackend/domain/politician/repository/PoliticianTrustScoreRepository.java
+++ b/src/main/java/com/factseekerbackend/domain/politician/repository/PoliticianTrustScoreRepository.java
@@ -16,6 +16,9 @@ public interface PoliticianTrustScoreRepository extends JpaRepository<Politician
 
   Optional<PoliticianTrustScore> findByPoliticianIdAndAnalysisDate(Long politicianId, LocalDate analysisDate);
 
+  @Query("SELECT pts FROM PoliticianTrustScore pts WHERE pts.politician.id = :politicianId ORDER BY pts.analysisDate DESC")
+  List<PoliticianTrustScore> findByPoliticianIdOrderByAnalysisDateDesc(@Param("politicianId") Long politicianId);
+
   @Query("SELECT pts FROM PoliticianTrustScore pts WHERE pts.politician.id = :politicianId AND pts.analysisStatus = 'COMPLETED' ORDER BY pts.analysisDate DESC LIMIT 1")
   Optional<PoliticianTrustScore> findLatestCompletedScore(@Param("politicianId") Long politicianId);
 


### PR DESCRIPTION
## ✅ 작업 내용
인물 분석 실행 시 날짜가 다른 경우 새로운 row를 만들지 않고, 기존 row의 값을 업데이트합니다.