### PR TITLE
hotfix: 인기 유튜브 및 fastapi 호출 24시간으로 수정

### DIFF
--- a/src/main/java/com/factseekerbackend/domain/analysis/service/fastapi/FastApiBridgeService.java
+++ b/src/main/java/com/factseekerbackend/domain/analysis/service/fastapi/FastApiBridgeService.java
@@ -42,7 +42,7 @@ public class FastApiBridgeService {
     /**
      * 스케줄 B: 매 시 정각 + 10초에 FastAPI 호출 시작
      */
-    @Scheduled(cron = "10 0 * * * *", zone = "Asia/Seoul")
+    @Scheduled(cron = "10 0 0 * * *", zone = "Asia/Seoul")
     public void callFastApiForTop10() {
         String tag = OffsetDateTime.now(KST).format(LOCK_FMT);
 

--- a/src/main/java/com/factseekerbackend/domain/youtube/service/PopularCacheRefresher.java
+++ b/src/main/java/com/factseekerbackend/domain/youtube/service/PopularCacheRefresher.java
@@ -12,7 +12,7 @@ public class PopularCacheRefresher {
 
     private final PopularPoliticsService popularPoliticsService;
 
-    @Scheduled(cron = "0 0 * * * *", zone = "Asia/Seoul")
+    @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
     public void refreshPopularPolitics() {
         try {
             // Top10을 규칙적으로 갱신 (Redis 해시 + 동일 timestamp)


### PR DESCRIPTION
## ✅ 작업 내용
- 파이썬 서버 과부화로 수정했습니다.