### PR TITLE
유튜브 랭킹 순위 수정

### DIFF
--- a/src/main/java/com/factseekerbackend/domain/youtube/service/YoutubeSearchService.java
+++ b/src/main/java/com/factseekerbackend/domain/youtube/service/YoutubeSearchService.java
@@ -63,7 +63,7 @@ public class YoutubeSearchService implements YoutubeService {
 
         List<Video> items = request.execute().getItems();
         return items.stream()
-                .filter(v -> getDurationSecondsSafe(v) >= 181)
+                .filter(v -> getDurationSecondsSafe(v) >= 91)
                 .limit(size)
                 .map(VideoDto::from)
                 .toList();


### PR DESCRIPTION
## ✅ 작업 내용
- 유튜브 랭킹 영상 길이 91초 이상으로 수정했습니다.